### PR TITLE
refactor: Improve query to retrieve the latest measurement

### DIFF
--- a/src/main/java/com/ecarbon/gdsc/carbon/repository/WeeklyMeasurementsRepository.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/repository/WeeklyMeasurementsRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface WeeklyMeasurementsRepository extends MongoRepository<WeeklyMeasurements, String> {
-    Optional<WeeklyMeasurements> findByUrl(String url);
+    Optional<WeeklyMeasurements> findTopByUrlOrderByMeasuredAtDesc(String url); // 최신 데이터 조회
 }

--- a/src/main/java/com/ecarbon/gdsc/carbon/service/CarbonAnalysisService.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/service/CarbonAnalysisService.java
@@ -33,7 +33,7 @@ public class CarbonAnalysisService {
     public Optional<CarbonAnalysisResponse> analyzeCarbonByUrl(String url) {
 
         try {
-            Optional<WeeklyMeasurements> weeklyDataOpt = weeklyMeasurementsRepository.findByUrl(url);
+            Optional<WeeklyMeasurements> weeklyDataOpt = weeklyMeasurementsRepository.findTopByUrlOrderByMeasuredAtDesc(url);
 
             if (weeklyDataOpt.isEmpty()) {
                 return Optional.empty();


### PR DESCRIPTION
The query to find weekly measurements by URL has been updated to retrieve the most recent measurement based on the `measuredAt` timestamp.  This ensures that only the latest data is returned.