### PR TITLE
feat: Add placeCategory parameter to getGlobalStats

### DIFF
--- a/src/main/java/com/ecarbon/gdsc/carbon/controller/GlobalStatsController.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/controller/GlobalStatsController.java
@@ -1,6 +1,7 @@
 package com.ecarbon.gdsc.carbon.controller;
 
 import com.ecarbon.gdsc.carbon.dto.GlobalStatsResponse;
+import com.ecarbon.gdsc.carbon.enums.PlaceCategory;
 import com.ecarbon.gdsc.carbon.service.GlobalStatsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 
 @Slf4j
@@ -21,10 +25,19 @@ public class GlobalStatsController {
 
     @GetMapping
     public ResponseEntity<GlobalStatsResponse> getGlobalStats(
-            @RequestParam String weekStartDate){
-        log.info("전체 통계 조회 요청: weekStartDate={}, limit={}", weekStartDate);
+            @RequestParam(required = false) String weekStartDate,
+            @RequestParam(defaultValue = "UNIVERSITY") PlaceCategory placeCategory) {
 
-        return globalStatsService.getGlobalStats(weekStartDate)
+        // deafult는 세션에서 받아오는 방식으로 변경 필요
+        if (weekStartDate == null || weekStartDate.isBlank()) {
+            LocalDate now = LocalDate.now();
+            weekStartDate = now.with(java.time.DayOfWeek.MONDAY)
+                    .format(DateTimeFormatter.ISO_DATE);
+        }
+
+        log.info("전체 통계 조회 요청: weekStartDate={}, placeType={}", weekStartDate, placeCategory);
+
+        return globalStatsService.getGlobalStats(weekStartDate, placeCategory)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }

--- a/src/main/java/com/ecarbon/gdsc/carbon/dto/GlobalStatsResponse.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/dto/GlobalStatsResponse.java
@@ -1,5 +1,6 @@
 package com.ecarbon.gdsc.carbon.dto;
 
+import com.ecarbon.gdsc.carbon.enums.PlaceCategory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,10 +10,10 @@ import java.util.List;
 @Getter
 public class GlobalStatsResponse {
 
-//    private String target;
+    private String weekStartDate;
+    private String placeCategory;
 
     private List<TopEmissionPlace> topEmissionPlaces;
     private double averageEmissionOfTopPlaces;
-//    private List<RegionEmission> regionalAverages;
 
 }

--- a/src/main/java/com/ecarbon/gdsc/carbon/enums/PlaceCategory.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/enums/PlaceCategory.java
@@ -1,0 +1,14 @@
+package com.ecarbon.gdsc.carbon.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum PlaceCategory {
+
+    UNIVERSITY("University"),
+    PUBLIC_INSTITUTION("PublicInstitution");
+
+    private final String value;
+}

--- a/src/main/java/com/ecarbon/gdsc/carbon/repository/WeeklyMeasurementsRepository.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/repository/WeeklyMeasurementsRepository.java
@@ -13,9 +13,9 @@ public interface WeeklyMeasurementsRepository extends MongoRepository<WeeklyMeas
     Optional<WeeklyMeasurements> findTopByUrlOrderByMeasuredAtDesc(String url);
 
     @Aggregation(pipeline = {
-            "{ $match: { 'weekStartDate': ?0 } }",
+            "{ $match: { 'weekStartDate': ?0, 'placeInfo.category': ?1 } }",
             "{ $sort: { 'carbonEmission': 1 } }",
-            "{ $limit: ?1 }"
+            "{ $limit: ?2 }"
     })
-    List<WeeklyMeasurements> findLowestCarbonEmissions(String weekStartDate, int limit);
+    List<WeeklyMeasurements> findLowestCarbonEmissions(String weekStartDate, String category, int limit);
 }

--- a/src/main/java/com/ecarbon/gdsc/carbon/service/GlobalStatsService.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/service/GlobalStatsService.java
@@ -3,16 +3,18 @@ package com.ecarbon.gdsc.carbon.service;
 import com.ecarbon.gdsc.carbon.dto.GlobalStatsResponse;
 import com.ecarbon.gdsc.carbon.dto.TopEmissionPlace;
 import com.ecarbon.gdsc.carbon.entity.WeeklyMeasurements;
+import com.ecarbon.gdsc.carbon.enums.PlaceCategory;
 import com.ecarbon.gdsc.carbon.repository.WeeklyMeasurementsRepository;
 import com.ecarbon.gdsc.carbon.util.CarbonGradeUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GlobalStatsService {
@@ -20,9 +22,9 @@ public class GlobalStatsService {
 
     private static int TopLimit = 5;
 
-    public Optional<GlobalStatsResponse> getGlobalStats(String weekStartDate){
+    public Optional<GlobalStatsResponse> getGlobalStats(String weekStartDate, PlaceCategory placeCategory){
 
-        List<TopEmissionPlace> topEmissionPlaces = getTopEmissionPlaces(weekStartDate, TopLimit);
+        List<TopEmissionPlace> topEmissionPlaces = getTopEmissionPlaces(weekStartDate, placeCategory, TopLimit);
 
         double average = topEmissionPlaces.stream()
                 .mapToDouble(TopEmissionPlace::getCarbonEmission)
@@ -32,6 +34,8 @@ public class GlobalStatsService {
         average = Math.round(average * 100.0) / 100.0;
 
         GlobalStatsResponse response = GlobalStatsResponse.builder()
+                .weekStartDate(weekStartDate)
+                .placeCategory(placeCategory.getValue())
                 .averageEmissionOfTopPlaces(average)
                 .topEmissionPlaces(topEmissionPlaces)
                 .build();
@@ -39,9 +43,11 @@ public class GlobalStatsService {
         return Optional.of(response);
     }
 
-    private List<TopEmissionPlace> getTopEmissionPlaces(String weekStartDate, int limit){
+    private List<TopEmissionPlace> getTopEmissionPlaces(String weekStartDate, PlaceCategory placeCategory, int limit){
 
-        List<WeeklyMeasurements> measurements = weeklyMeasurementsRepository.findLowestCarbonEmissions(weekStartDate, limit);
+        log.info(placeCategory.getValue());
+
+        List<WeeklyMeasurements> measurements = weeklyMeasurementsRepository.findLowestCarbonEmissions(weekStartDate, placeCategory.getValue() ,limit);
         List<TopEmissionPlace> topEmissionPlaces = new ArrayList<>();
 
         int rank = 1;


### PR DESCRIPTION
This commit adds a `placeCategory` parameter to the `getGlobalStats` method in the
`GlobalStatsController`. This allows the API to
return global statistics filtered by place category.

feat(GlobalStatsResponse): Add weekStartDate and placeCategory fields

This commit adds `weekStartDate` and `placeCategory` fields to the `GlobalStatsResponse` DTO.  These fields provide more context to the returned global statistics.

feat(PlaceCategory): Create PlaceCategory enum

This commit introduces a new enum, `PlaceCategory`, to represent different categories of places (e.g.,
University, PublicInstitution). This improves code readability and maintainability.

refactor(WeeklyMeasurementsRepository): Modify
findLowestCarbonEmissions method

This commit modifies the
`findLowestCarbonEmissions` method in the
`WeeklyMeasurementsRepository` to accept a
`placeCategory` parameter. This allows filtering
results by place category.

refactor(GlobalStatsService): Refactor getGlobalStats method

This commit refactors the `getGlobalStats` method in the `GlobalStatsService` to use the new
`PlaceCategory` enum and handle optional
`weekStartDate` parameter.  This improves the
method's flexibility and clarity.

chore(GlobalStatsController): Add default value for weekStartDate

This commit adds a default value for the
`weekStartDate` parameter in the `getGlobalStats`
method. If no `weekStartDate` is provided, the
default value will be used.  This improves the API's user experience.