### PR TITLE
feat: Add globalAvgCarbon field

### DIFF
--- a/src/main/java/com/ecarbon/gdsc/carbon/dto/CarbonAnalysisResponse.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/dto/CarbonAnalysisResponse.java
@@ -36,7 +36,7 @@ public class CarbonAnalysisResponse {
 
     // global_avg_carbon    (세계 평균)     -> round(estimate_emission_per_page(0.002344), 2)
     // korea_avg_carbon     (한국 평균)     -> round(estimate_emission_per_page(0.00456), 2)
-
+    private double globalAvgCarbon;
 
     // korea_diff       (한국 평균과의 차이)            -> round(korea_diff, 2)
     // global_diff      (세계 평균과의 차이)            -> round(global_diff, 2)

--- a/src/main/java/com/ecarbon/gdsc/carbon/service/CarbonAnalysisService.java
+++ b/src/main/java/com/ecarbon/gdsc/carbon/service/CarbonAnalysisService.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 public class CarbonAnalysisService {
 
     private final WeeklyMeasurementsRepository weeklyMeasurementsRepository;
+    private final CarbonCalculator calculator;
 
     public Optional<CarbonAnalysisResponse> analyzeCarbonByUrl(String url) {
 
@@ -48,6 +49,7 @@ public class CarbonAnalysisService {
                 long totalByteWeight = weeklyData.getTotalByteWeight();
                 double kbWeight = weeklyData.getKbWeight();
                 double carbonEmission = weeklyData.getCarbonEmission();
+
                 List<ResourcePercentage> resourcePercentages = calculateResourcePercentages(weeklyData.getResourceSummaries());
                 CarbonEquivalents equivalents = calculateCarbonEquivalents(carbonEmission);
                 String grade = CarbonGradeUtil.calculateGrade(totalByteWeight);
@@ -57,6 +59,7 @@ public class CarbonAnalysisService {
                         .resourcePercentage(resourcePercentages)
                         .carbonEquivalents(equivalents)
                         .carbonEmission(carbonEmission)
+                        .globalAvgCarbon(0.8)
                         .kbWeight(kbWeight)
                         .grade(grade)
                         .build();
@@ -92,8 +95,6 @@ public class CarbonAnalysisService {
                 .collect(Collectors.toList());
     }
 
-
-
     private CarbonEquivalents calculateCarbonEquivalents(double carbonEmission){
 
         double factor = carbonEmission / 1000 * 10000  * 12;
@@ -105,4 +106,5 @@ public class CarbonAnalysisService {
                 .trees(Math.round(factor / 0.02 * 1))
                 .build();
     }
+
 }


### PR DESCRIPTION
This commit adds a new field `globalAvgCarbon` to the `CarbonAnalysisResponse` DTO. This field will store the average global carbon emissions.